### PR TITLE
Refactoring

### DIFF
--- a/Controller/PageController.php
+++ b/Controller/PageController.php
@@ -14,9 +14,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use CampaignChain\CoreBundle\Entity\Campaign;
 use Symfony\Component\HttpFoundation\Request;
 use Doctrine\ORM\EntityRepository;
-use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 
 class PageController extends Controller
 {

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -10,4 +10,6 @@ parameters:
 services:
     campaignchain.report.analytics.metrics_per_activity.data:
         class: CampaignChain\Report\Analytics\MetricsPerActivityBundle\Util\Data
-        arguments: ["@doctrine.orm.entity_manager"]
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@campaignchain.core.serializer.default'

--- a/Util/Data.php
+++ b/Util/Data.php
@@ -11,10 +11,7 @@
 namespace CampaignChain\Report\Analytics\MetricsPerActivityBundle\Util;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\EntityRepository;
-use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+use Symfony\Component\Serializer\SerializerInterface;
 
 class Data
 {
@@ -44,14 +41,12 @@ class Data
 
     public $milestonesData = null;
 
-    public function __construct(EntityManager $em)
+    public function __construct(EntityManager $em, SerializerInterface $serializer)
     {
         $this->em = $em;
 
         // We'll need the serializer later
-        $encoders = array(new JsonEncoder());
-        $normalizers = array(new GetSetMethodNormalizer());
-        $this->serializer = new Serializer($normalizers, $encoders);
+        $this->serializer = $serializer;
     }
 
     public function setCampaign($campaign){


### PR DESCRIPTION
- fix code style
- extract queries to CampaignChainCoreBundle:Campaign repository
- remove unused namespace imports
- extract form generation to getCampaignType() to reduce boiler plate
- use $this->addFlash() instead of $this->get('session')->getFlashBag()->add()
- use $this->redirectToRoute() instead of $this->redirect($this->generateUrl())
- rename $repository to $em, because it contains the Entity Manager and not a repository
- replace serializer generation with a serializer service to reduce boiler plate
- inject serializer service where necessary
- remove unnecessary $response variable
- remove unnecessary $response->setStatusCode(Response::HTTP_OK) - it's already the default
